### PR TITLE
bunch of changes - see details

### DIFF
--- a/src/mw/clicommands.py
+++ b/src/mw/clicommands.py
@@ -154,19 +154,21 @@ class PullCategoryMembersCommand(CommandBase):
             self.query_continue = api_call['query-continue']['categorymembers']['gcmcontinue']
         else:
             self.query_continue = ''
-        response = api_call['query']['pages']
-        pull_command = PullCommand()
-        pull_command.args = []
+        if api_call != [] :
+ 
+            response = api_call['query']['pages']
+            pull_command = PullCommand()
+            pull_command.args = []
 
-        for pageid in response.keys():
-            pagename = response[pageid]['title']
-            pull_command.args += [pagename.encode('utf-8')]
+            for pageid in response.keys():
+                 pagename = response[pageid]['title']
+                 pull_command.args += [pagename.encode('utf-8')]
 
-        pull_command._do_command()
+            pull_command._do_command()
 
-        if self.query_continue != '':
-            print 'query continue detected - continuing the query'
-            self._do_command()
+            if self.query_continue != '':
+                 print 'query continue detected - continuing the query'
+                 self._do_command()
 
 
 

--- a/src/mw/clicommands.py
+++ b/src/mw/clicommands.py
@@ -426,12 +426,14 @@ class CommitCommand(CommandBase):
                         fd.write(data)
                     if files_to_commit :
                         end_time = time.time()
-                        print time.strftime("%Y-%m-%d - %H:%M:%S", time.gmtime(time.time()))
+                        print time.strftime("%Y-%m-%d - %H:%M:%S", time.gmtime(time.time())) \
+                            + " - Committed - " + mw.metadir.filename_to_pagename(filename[:-5]) \
+                            + " - Files left: " + str(files_to_commit)
                         time_inc = end_time - start_time
                         delay = 10 - time_inc
                         if delay > 0 :
                             print "adjusting throttle - waiting for %.2fs" % delay
-                            time.sleep(delay)
+                            time.sleep(delay) 
                 else:
                     print 'error: committing %s failed: %s' % \
                             (filename, response['edit']['result'])

--- a/src/mw/clicommands.py
+++ b/src/mw/clicommands.py
@@ -77,12 +77,15 @@ class CommandBase(object):
         if self.metadir.config is None:
             print '%s: not a mw repo' % self.me
             sys.exit(1)
+        self.api_setup = False
 
     def _api_setup(self):
-        cookie_filename = os.path.join(self.metadir.location, 'cookies')
-        self.api_url = self.metadir.config.get('remote', 'api_url')
-        self.api = simplemediawiki.MediaWiki(self.api_url,
+        if not self.api_setup: # do not call _api_setup twice
+            cookie_filename = os.path.join(self.metadir.location, 'cookies')
+            self.api_url = self.metadir.config.get('remote', 'api_url')
+            self.api = simplemediawiki.MediaWiki(self.api_url,
                                              cookie_file=cookie_filename)
+            self.api_setup = True
 
 
 class InitCommand(CommandBase):

--- a/src/mw/clicommands.py
+++ b/src/mw/clicommands.py
@@ -301,7 +301,7 @@ class MergeCommand(CommandBase):
                 os.rename(full_filename, full_filename + '.local')
                 # pull wiki copy
                 pull_command = PullCommand()
-                pull_command.args = [pagename.encode('utf-8')]
+                pull_command.args = [pagename]#.encode('utf-8')] #assuming the file is already using utf-8 - esby
                 pull_command._do_command()
                 # mv remote to filename.wiki.remote
                 os.rename(full_filename, full_filename + '.remote')
@@ -315,7 +315,7 @@ class MergeCommand(CommandBase):
                 os.remove(full_filename + '.remote')
                 # mw ci pagename
                 commit_command = CommitCommand()
-                commit_command.args = [pagename.encode('utf-8')]
+                commit_command.args = [pagename]#.encode('utf-8')] #assuming the file is already using utf-8 - esby
                 commit_command._do_command()
 
 
@@ -352,6 +352,7 @@ class CommitCommand(CommandBase):
             edit_summary = self.options.edit_summary
         for filename in status:
             if status[filename] in ['M']:
+                start_time = time.time()
                 files_to_commit -= 1
                 # get edit token
                 data = {
@@ -424,8 +425,13 @@ class CommitCommand(CommandBase):
                         data = data.encode('utf-8')
                         fd.write(data)
                     if files_to_commit :
-                        print 'waiting 3s before processing the next file'
-                        time.sleep(3)
+                        end_time = time.time()
+                        print time.strftime("%Y-%m-%d - %H:%M:%S", time.gmtime(time.time()))
+                        time_inc = end_time - start_time
+                        delay = 10 - time_inc
+                        if delay > 0 :
+                            print "adjusting throttle - waiting for %.2fs" % delay
+                            time.sleep(delay)
                 else:
                     print 'error: committing %s failed: %s' % \
                             (filename, response['edit']['result'])

--- a/src/mw/metadir.py
+++ b/src/mw/metadir.py
@@ -51,7 +51,6 @@ class Metadir(object):
 
     def pagedict_load(self):
         if not self.pagedict_loaded:
-            print "loading pagedict"
             fd = file(os.path.join(self.location, 'cache', 'pagedict'), 'r+')
             self.pagedict = json.loads(fd.read())
             fd.close

--- a/src/mw/metadir.py
+++ b/src/mw/metadir.py
@@ -78,7 +78,7 @@ class Metadir(object):
         self.config.add_section('merge')
         self.config.set('merge', 'tool', 'kidff3 %s %s -o %s')
         self.config.add_section('index')
-        self.config.set('index''use_md5','on')
+        self.config.set('index', 'use_md5','on')
         self.save_config()
         # create cache/
         os.mkdir(os.path.join(self.location, 'cache'))

--- a/src/mw/metadir.py
+++ b/src/mw/metadir.py
@@ -25,16 +25,6 @@ from StringIO import StringIO
 import sys
 import hashlib
 
-# function taken from http://code.activestate.com/recipes/466341-guaranteed-conversion-to-unicode-or-byte-string/
-# used to handle some weird case with accentued characters in filename 
-# eg: http://commons.wikimedia.org/wiki/File:Jean-Louis_Debr%C3%A9_14_mars_2009.jpg
-def safe_str(obj):
-    """ return the byte string representation of obj """
-    try:
-        return str(obj)
-    except UnicodeEncodeError:
-        # obj is unicode
-        return unicode(obj).encode('unicode_escape')
 
 class Metadir(object):
 
@@ -122,7 +112,7 @@ class Metadir(object):
 
     def get_md5_from_pagename(self, pagename):
         m = hashlib.md5()
-        name = safe_str(pagename)
+        name = pagename.encode('unicode_escape') 
         m.update(name)
         return os.path.join(self.location, 'cache', 'md5index', m.hexdigest())
 

--- a/src/mw/metadir.py
+++ b/src/mw/metadir.py
@@ -47,6 +47,15 @@ class Metadir(object):
             self.config.read(self.config_loc)
         else:
             self.config = None
+        self.pagedict_loaded = False
+
+    def pagedict_load(self):
+        if not self.pagedict_loaded:
+            print "loading pagedict"
+            fd = file(os.path.join(self.location, 'cache', 'pagedict'), 'r+')
+            self.pagedict = json.loads(fd.read())
+            fd.close
+            self.pagedict_loaded = True
 
     def save_config(self):
         with open(self.config_loc, 'wb') as config_file:
@@ -89,20 +98,18 @@ class Metadir(object):
         fd.close()
 
     def pagedict_add(self, pagename, pageid, currentrv):
-        fd = file(os.path.join(self.location, 'cache', 'pagedict'), 'r+')
-        pagedict = json.loads(fd.read())
-        pagedict[pagename] = {'id': int(pageid), 'currentrv': int(currentrv)}
-        fd.seek(0)
-        fd.write(json.dumps(pagedict))
+        self.pagedict_load()
+        self.pagedict[pagename] = {'id': int(pageid), 'currentrv': int(currentrv)}
+        fd = file(os.path.join(self.location, 'cache', 'pagedict'), 'w')
+        fd.write(json.dumps(self.pagedict))
         fd.truncate()
         fd.close()
 
     def get_pageid_from_pagename(self, pagename):
-        fd = file(os.path.join(self.location, 'cache', 'pagedict'), 'r')
-        pagedict = json.loads(fd.read())
+        self.pagedict_load()
         pagename = pagename.decode('utf-8')
-        if pagename in pagedict.keys():
-            return pagedict[pagename]
+        if pagename in self.pagedict.keys():
+            return self.pagedict[pagename]
         else:
             return None
 


### PR DESCRIPTION
metadir_py:
- alternate cache structure: by using an md5 hash of the filename of each file downloaded.
- little improvement to the old cache structure when pulling category member:
  the pagedict won't reload from disk each time a page is pulled.

clicommands.py:
- quick fix for merge command - I believe files are already in utf8 because they comes from os calls.
- rewrote throttle: a 10s delay here will mean it will take into account the request time, From my tests, it will take about 11s to commit a file. (3 api access of 3.75s). The next step will be implementing the value in metadir config.
- more verbose when committing files. date - filename - number of files left
- implemented continue for category member pulling.
- do not set api_setup again if it was already done.

If you think the code needs rework to fit needs, just ask.
